### PR TITLE
Handle VersionConflict in `load_setuptools_entrypoints`

### DIFF
--- a/pluggy.py
+++ b/pluggy.py
@@ -492,7 +492,8 @@ class PluginManager(object):
     def load_setuptools_entrypoints(self, entrypoint_name):
         """ Load modules from querying the specified setuptools entrypoint name.
         Return the number of loaded plugins. """
-        from pkg_resources import iter_entry_points, DistributionNotFound
+        from pkg_resources import (iter_entry_points, DistributionNotFound,
+                                   VersionConflict)
         for ep in iter_entry_points(entrypoint_name):
             # is the plugin registered or blocked?
             if self.get_plugin(ep.name) or self.is_blocked(ep.name):
@@ -501,6 +502,9 @@ class PluginManager(object):
                 plugin = ep.load()
             except DistributionNotFound:
                 continue
+            except VersionConflict as e:
+                raise PluginValidationError(
+                    "Plugin %r could not be loaded: %s!" % (ep.name, e))
             self.register(plugin, name=ep.name)
             self._plugin_distinfo.append((plugin, ep.dist))
         return len(self._plugin_distinfo)


### PR DESCRIPTION
This is an attempt at addressing https://github.com/hpk42/pluggy/issues/7.

It might get handled better, e.g. in pytest itself, but this makes it at least be more verbose and mentions the source of the error (the plugin causing it).

    Traceback (most recent call last):
      File "…/pluggy/pluggy.py", line 502, in load_setuptools_entrypoints
        plugin = ep.load()
      File "…/pyenv/project/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2354, in load
        self.require(*args, **kwargs)
      File "…/pyenv/project/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2371, in require
        items = working_set.resolve(reqs, env, installer)
      File "…/pyenv/project/lib/python3.4/site-packages/pkg_resources/__init__.py", line 844, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.VersionConflict: (coverage 4.0b3 (…/pyenv/project/lib/python3.4/site-packages), Requirement.parse('coverage<4.0,>=3.7.1'))

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "…/pyenv/project/bin/py.test", line 9, in <module>
        load_entry_point('pytest==2.7.3.dev410+ng8625eb6', 'console_scripts', 'py.test')()
      File "…/pytest/_pytest/config.py", line 38, in main
        config = _prepareconfig(args, plugins)
      File "…/pytest/_pytest/config.py", line 117, in _prepareconfig
        pluginmanager=pluginmanager, args=args)
      File "…/pluggy/pluggy.py", line 728, in __call__
        return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
      File "…/pluggy/pluggy.py", line 338, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
      File "…/pluggy/pluggy.py", line 333, in <lambda>
        _MultiCall(methods, kwargs, hook.spec_opts).execute()
      File "…/pluggy/pluggy.py", line 599, in execute
        return _wrapped_call(hook_impl.function(*args), self.execute)
      File "…/pluggy/pluggy.py", line 249, in _wrapped_call
        wrap_controller.send(call_outcome)
      File "…/pytest/_pytest/helpconfig.py", line 28, in pytest_cmdline_parse
        config = outcome.get_result()
      File "…/pluggy/pluggy.py", line 278, in get_result
        raise ex[1].with_traceback(ex[2])
      File "…/pluggy/pluggy.py", line 264, in __init__
        self.result = func()
      File "…/pluggy/pluggy.py", line 600, in execute
        res = hook_impl.function(*args)
      File "…/pytest/_pytest/config.py", line 851, in pytest_cmdline_parse
        self.parse(args)
      File "…/pytest/_pytest/config.py", line 956, in parse
        self._preparse(args)
      File "…/pytest/_pytest/config.py", line 917, in _preparse
        self.pluginmanager.load_setuptools_entrypoints("pytest11")
      File "…/pluggy/pluggy.py", line 507, in load_setuptools_entrypoints
        "Plugin %r could not be loaded: %s!" % (ep.name, e))
    pluggy.PluginValidationError: Plugin 'testmon' could not be loaded: (coverage 4.0b3 (…/pyenv/project/lib/python3.4/site-packages), Requirement.parse('coverage<4.0,>=3.7.1'))!
    ―
