### PR TITLE
Use inspect.signature instead of inspect.getargspec

### DIFF
--- a/pluggy.py
+++ b/pluggy.py
@@ -763,8 +763,16 @@ class PluginValidationError(Exception):
     """ plugin failed validation. """
 
 
-def _formatdef(func):
-    return "%s%s" % (
-        func.__name__,
-        inspect.formatargspec(*inspect.getargspec(func))
-    )
+
+if hasattr(inspect, 'signature'):
+    def _formatdef(func):
+        return "%s%s" % (
+            func.__name__,
+            str(inspect.signature(func))
+        )
+else:
+    def _formatdef(func):
+        return "%s%s" % (
+            func.__name__,
+            inspect.formatargspec(*inspect.getargspec(func))
+        )

--- a/test_pluggy.py
+++ b/test_pluggy.py
@@ -6,7 +6,7 @@ import pytest
 from pluggy import (PluginManager, varnames, PluginValidationError,
                     HookimplMarker, HookspecMarker)
 
-from pluggy import (_MultiCall, _TagTracer, HookImpl)
+from pluggy import (_MultiCall, _TagTracer, HookImpl, _formatdef)
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
@@ -663,6 +663,21 @@ def test_varnames_class():
 
     assert varnames(C) == ("x",)
     assert varnames(D) == ()
+
+
+def test_formatdef():
+    def function1(): pass
+    assert _formatdef(function1) == 'function1()'
+
+    def function2(arg1): pass
+    assert _formatdef(function2) == "function2(arg1)"
+
+    def function3(arg1, arg2="qwe"): pass
+    assert _formatdef(function3) == "function3(arg1, arg2='qwe')"
+
+    def function4(arg1, *args, **kwargs): pass
+    assert _formatdef(function4) == "function4(arg1, *args, **kwargs)"
+
 
 
 class Test_MultiCall:


### PR DESCRIPTION
inspect.getargspec is deprecated on Python 3.5

This is the corollary to pytest-dev/pytest#1009