### PR TITLE
Make pluggy more resilient when registering plugins with bad attributes

### DIFF
--- a/pluggy.py
+++ b/pluggy.py
@@ -375,7 +375,10 @@ class PluginManager(object):
 
     def parse_hookimpl_opts(self, plugin, name):
         method = getattr(plugin, name)
-        res = getattr(method, self.project_name + "_impl", None)
+        try:
+            res = getattr(method, self.project_name + "_impl", None)
+        except Exception:
+            res = {}
         if res is not None and not isinstance(res, dict):
             # false positive
             res = None
@@ -640,7 +643,10 @@ def varnames(func, startindex=None):
         startindex = 1
     else:
         if not inspect.isfunction(func) and not inspect.ismethod(func):
-            func = getattr(func, '__call__', func)
+            try:
+                func = getattr(func, '__call__', func)
+            except Exception:
+                return ()
         if startindex is None:
             startindex = int(inspect.ismethod(func))
 

--- a/testing/test_pluggy.py
+++ b/testing/test_pluggy.py
@@ -645,6 +645,26 @@ def test_parse_hookimpl_override():
     assert pm.hook.x1meth2._wrappers[0].hookwrapper
 
 
+def test_plugin_getattr_raises_errors():
+    """Pluggy must be able to handle plugins which raise weird exceptions
+    when getattr() gets called (#11).
+    """
+    class DontTouchMe:
+        def __getattr__(self, x):
+            raise Exception('cant touch me')
+
+    class Module:
+        pass
+
+    module = Module()
+    module.x = DontTouchMe()
+
+    pm = PluginManager(hookspec.project_name)
+    # register() would raise an error
+    pm.register(module, 'donttouch')
+    assert pm.get_plugin('donttouch') is module
+
+
 def test_varnames():
     def f(x):
         i = 3  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ minversion=2.0
 #--pyargs --doctest-modules --ignore=.tox
 addopts= -rxsX 
 pep8ignore = E501 E128 E127
-norecursedirs = .tox ja .hg
+norecursedirs = .tox ja .hg .env*


### PR DESCRIPTION
Fix #11 

Unfortunately this is not enough to solve the issue in Pytest, after this change I still get an error:

```
  File "X:\pluggy\.env34\lib\site-packages\_pytest\config.py", line 206, in register
    ret = super(PytestPluginManager, self).register(plugin, name)
  File "X:\pluggy\.env34\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 360, in register
    hookimpl_opts = self.parse_hookimpl_opts(plugin, name)
  File "X:\pluggy\.env34\lib\site-packages\_pytest\config.py", line 181, in parse_hookimpl_opts
    opts.setdefault(name, hasattr(method, name))
  File "X:\pluggy\t\conftest.py", line 3, in __getattr__
    raise Exception('cant touch me')
Exception: cant touch me
```